### PR TITLE
Lida com métodos não permitidos nas requisições da `api/v1/status`. 

### DIFF
--- a/infra/errors/index.js
+++ b/infra/errors/index.js
@@ -16,3 +16,19 @@ export class InternalServerError extends Error {
     };
   }
 }
+export class MethodNotAllowedError extends Error {
+  constructor() {
+    super("O método utilizado não é permitido.");
+    this.name = "MethodNotAllowed";
+    this.action = "Utilize um método válido.";
+    this.statusCode = 405;
+  }
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      statusCode: this.statusCode,
+    };
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "16.4.5",
         "dotenv-expand": "11.0.6",
         "next": "14.2.24",
+        "next-connect": "1.0.0",
         "node-pg-migrate": "7.6.1",
         "pg": "8.12.0",
         "react": "18.3.1",
@@ -2071,6 +2072,12 @@
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -8742,6 +8749,19 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9761,6 +9781,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dotenv": "16.4.5",
     "dotenv-expand": "11.0.6",
     "next": "14.2.24",
+    "next-connect": "1.0.0",
     "node-pg-migrate": "7.6.1",
     "pg": "8.12.0",
     "react": "18.3.1",

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -3,53 +3,50 @@ import database from "infra/database.js";
 import { InternalServerError, MethodNotAllowedError } from "infra/errors";
 
 const router = createRouter();
-router.get(status);
+router.get(getHandler);
 export default router.handler({
   onNoMatch: onNoMatch,
+  onError: publicError,
 });
 
-function onNoMatch(request, response) {
-  const publicError = new MethodNotAllowedError();
+function publicError(error, request, response) {
+  const publicError = new InternalServerError(error);
   response.status(publicError.statusCode).json(publicError);
 }
 
-async function status(request, response) {
-  try {
-    const updatedAt = new Date().toISOString();
+function onNoMatch(request, response) {
+  const publicMethodError = new MethodNotAllowedError();
+  response.status(publicMethodError.statusCode).json(publicMethodError);
+}
 
-    const databaseVersionResult = await database.query("SHOW server_version;");
-    const databaseVersionValue = databaseVersionResult.rows[0].server_version;
+async function getHandler(request, response) {
+  const updatedAt = new Date().toISOString();
 
-    const databaseMaxConnectionsResult = await database.query(
-      "SHOW max_connections",
-    );
-    const databaseMaxConnectionsValue =
-      databaseMaxConnectionsResult.rows[0].max_connections;
+  const databaseVersionResult = await database.query("SHOW server_version;");
+  const databaseVersionValue = databaseVersionResult.rows[0].server_version;
 
-    const databaseName = process.env.POSTGRES_DB;
-    const dabatabaseOpenedConnectionsValue = await database.query({
-      text: "SELECT count(*)::int FROM pg_stat_activity WHERE datname = $1;",
-      values: [databaseName],
-    });
-    const dabatabaseOpenedConnectionsResult =
-      dabatabaseOpenedConnectionsValue.rows[0].count;
+  const databaseMaxConnectionsResult = await database.query(
+    "SHOW max_connections",
+  );
+  const databaseMaxConnectionsValue =
+    databaseMaxConnectionsResult.rows[0].max_connections;
 
-    response.status(200).json({
-      updated_at: updatedAt,
-      dependecies: {
-        database: {
-          version: databaseVersionValue,
-          max_connections: parseInt(databaseMaxConnectionsValue),
-          opened_connections: dabatabaseOpenedConnectionsResult,
-        },
+  const databaseName = process.env.POSTGRES_DB;
+  const dabatabaseOpenedConnectionsValue = await database.query({
+    text: "SELECT count(*)::int FROM pg_stat_activity WHERE datname = $1;",
+    values: [databaseName],
+  });
+  const dabatabaseOpenedConnectionsResult =
+    dabatabaseOpenedConnectionsValue.rows[0].count;
+
+  response.status(200).json({
+    updated_at: updatedAt,
+    dependecies: {
+      database: {
+        version: databaseVersionValue,
+        max_connections: parseInt(databaseMaxConnectionsValue),
+        opened_connections: dabatabaseOpenedConnectionsResult,
       },
-    });
-  } catch (error) {
-    const publicErrorObject = new InternalServerError({
-      cause: error,
-    });
-    console.error("\n Erro no Controller: ");
-    console.error(publicErrorObject);
-    response.status(500).json(publicErrorObject);
-  }
+    },
+  });
 }

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,5 +1,17 @@
+import { createRouter } from "next-connect";
 import database from "infra/database.js";
-import { InternalServerError } from "infra/errors";
+import { InternalServerError, MethodNotAllowedError } from "infra/errors";
+
+const router = createRouter();
+router.get(status);
+export default router.handler({
+  onNoMatch: onNoMatch,
+});
+
+function onNoMatch(request, response) {
+  const publicError = new MethodNotAllowedError();
+  response.status(publicError.statusCode).json(publicError);
+}
 
 async function status(request, response) {
   try {
@@ -41,4 +53,3 @@ async function status(request, response) {
     response.status(500).json(publicErrorObject);
   }
 }
-export default status;

--- a/tests/integrations/api/v1/status/post.test.js
+++ b/tests/integrations/api/v1/status/post.test.js
@@ -1,0 +1,25 @@
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  return;
+});
+
+describe("POST /api/v1/status", () => {
+  describe("Anonymous user", () => {
+    test("Retrieving current system status", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/status", {
+        method: "POST",
+      });
+      expect(response.status).toBe(405);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowed",
+        message: "O método utilizado não é permitido.",
+        action: "Utilize um método válido.",
+        statusCode: 405,
+      });
+    });
+  });
+});


### PR DESCRIPTION
Uso o módulo `next-connect` para abstrair e permitir apenas requisições utiliando o método `GET` na `API pública` e cubro tudo com o aquivo de teste `post.test.js`.
Crio um novo erro customizado para requisições com métodos não permitidos: `MethodNotAllowedError`